### PR TITLE
added specs for sec 6 demos

### DIFF
--- a/Assignments/demo-sec247.md
+++ b/Assignments/demo-sec247.md
@@ -1,0 +1,24 @@
+---
+layout: page
+title: Demos for Sections 2, 4, 7
+permalink: /assignments/sec-247-demos
+parent: Final Project Grading
+nav_order: 8
+---
+
+# Specifications for Fall 2023 Live Demos / Presentations (Sections 2, 4, 7 - Prof. Bhutta)
+
+Each group will present a live demo to show the feature that they have added to Covey.Town for the final project (the demo MUSt be from hosted website, NOT from localhost). The schedule of these demos will be discussed/finalized during the lecture. You will have 9 minutes maximum (8 minutes to setup and present. 1 minute for questions and everything else). You will lose points if your demo goes over 8 minutes. Please rehearse it and time yourself (best to keep it to 7 minutes or less). Attendance is REQUIRED for these demos.
+
+During your presentation, you might consider following this order: introduction of project idea/user stories, follow by live demo, then talk about the following:
+- description of feature(s) implemented (no more than 1 slide) - perhaps compare with what was proposed.
+- Tech stack and/or list of other/external components used (no more than 1 slide)
+- short summary of overall contribution by each member (no more than 1-2 sentences per member);
+- What percentage of overall contribution was made by each member (perhaps using weekly peer contribution scores)
+- estimated number of hours spent on the project by each member (for overall project);
+- what challenges were faced and how did you overcome them? Discuss any deviations from the proposed plan?
+
+You may also include your email address and any other related info (i.e., github repo link, hosted site link, etc). You should also submit a copy of your presentation (pptx/pdf file, not link) on Canvas.
+
+# Grading Rubric:
+Your final Poster and Demos are worth 4% of the overall course. Poster will be worth 1% and will be graded based on whether you submitted it on time or not. Demos will be worth 3% and will be graded using the following criteria: Each group will evaluate each others' demos and will assign scores (Instructor and TAs will do the same). Your final demo score will be calculated by combining all of these scores (equally weighted).

--- a/Assignments/demo-sec6.md
+++ b/Assignments/demo-sec6.md
@@ -1,0 +1,34 @@
+---
+layout: page
+title: Sec 6 Demos
+permalink: /assignments/sec-6-demos
+parent: Final Project Grading
+nav_order: 7
+---
+
+# Specifications for Fall 2023 Live Presentations (Sec 6, Prof. Wand)
+
+Each group will present a live demo for the final project. You can imagine this as the live presentation that you would make if you were standing in front of your poster at a conference. Imagine your target audience as a recruiter for a software engineering role: your goal is to demonstrate that you have some experience working on some non-trivial software engineering project. 
+
+We expect all students to attend the entire set of presentations. We *will* be taking attendance (via zoom logs). 
+
+You will have 10 minutes maximum (9 minutes to setup and present. 1 minute for questions and everything else). You will lose points if your demo goes over 9 minutes. Please rehearse it and time yourself (best to keep it to 8 minutes)! 
+
+Your presentation may be a combination of narrated slides and live demonstration. Your slides may reuse materials from your poster. The live demonstration must be run on the hosted site, rather than on your local machine.
+
+Your presentation should include the following:
+* A description of the feature you added
+* A live demonstration of your project, including all of the screenshots from your poster.
+* A summary of the technology stack and overall design decisions (this may also be taken from your poster)
+* Short summary of overall contribution by each member 
+* A summary of challenges were faced and how you overcame them (alternatively, how the project you delivered differed from the one you proposed).
+
+You should submit a copy of your pptx or pdf of your slides on Canvas.
+
+## Grading Rubric:
+Each of the elements above will be graded separately, with the following point value:
+* A description of the feature you added (1pt)
+* A live demonstration of your project, including all of the screenshots from your poster. (5 pts)
+* A summary of the technology stack and overall design decisions (2 pts)
+* Short summary of overall contribution by each member (1 pt)
+* A summary of challenges were faced and how you overcame them (alternatively, how the project you delivered differed from the one you proposed). (1 pt)

--- a/Assignments/project-deliverable.md
+++ b/Assignments/project-deliverable.md
@@ -38,11 +38,10 @@ Each team will submit a poster. Your poster will be a single-page document, that
 
 We've created a [sample poster for the "Conversation Areas" feature]({{ site.baseurl }}{% link Examples/conversation-areas-poster.pdf %}), which you might find useful in deciding how to format your poster. It's fine to use a different aspect ratio (e.g. portrait instead of landscape), and there are no specific requirements for font size or amount of text. Please try to create a document that you feel represents your project, imagine your target audience as a recruiter for a software engineering role: your goal is to demonstrate that you have some experience working on some non-trivial software engineering project.
 
-In addition, some sections will have live (in-person) demos and others may ask you to record a demo video. Details for project demos and/presentations will be provided during class by each instructor (and may vary from section to section). **Posters and/or demo videos and/or presentations will be submitted on Canvas**, under the assignment "Project: Poster / Demo".
+In addition, some sections will have live (in-person) demos and others may ask you to record a demo video. Details for project demos and/or presentations will be provided during class by each instructor (and may vary from section to section). **Posters and/or demo videos and/or presentations will be submitted on Canvas**, under the assignment "Project: Poster / Demo".
  
 #### Individual Reflection
 Create a PDF of your reflection, and submit it to Canvas, under the assignment "Project: Individual Reflection". 
 
 ## Grading
-
 Details on grading may be found at [Project Grading]({{ site.baseurl }}{% link Assignments/project-grading.md %})

--- a/Assignments/project-grading.md
+++ b/Assignments/project-grading.md
@@ -135,7 +135,8 @@ The allocation of the 10% credit will be as follows: Overview and manual will be
 
 ### Posters and Demo (10%)
 Each team will be required to submit a poster. In addition, some sections may have a demo (live in-person, via zoom or by recorded video). Each instructor will provide details regarding expectations for the demo and/or presentation. The schedule and manner of these demos might also vary from section to section.  The specifications for the different sections are listed below:
-* [Section 6](demo-sec6.md)
+* [Sections 2, 4, 7 - Prof. Bhutta](demo-sec247.md)
+* [Section 6 - Prof. Wand](demo-sec6.md)
 
 Select projects may be hosted in our project showcase. Here are selected projects from Fall 2022 [project showcase](https://neu-se.github.io/CS4530-Fall-2022/assignments/project-showcase).
 

--- a/Assignments/project-grading.md
+++ b/Assignments/project-grading.md
@@ -134,7 +134,8 @@ The allocation of the 10% credit will be as follows: Overview and manual will be
 * The document is at most 2 pages (fewer pages are absolutely acceptable, consider this a rough limit) 
 
 ### Posters and Demo (10%)
-Each team will be required to submit a poster. In addition, some sections may have a demo (live in-person, via zoom or by recorded video). Each instructor will provide details regarding expectations for the demo and/or presentation. The schedule and manner of these demos might also vary from section to section.
+Each team will be required to submit a poster. In addition, some sections may have a demo (live in-person, via zoom or by recorded video). Each instructor will provide details regarding expectations for the demo and/or presentation. The schedule and manner of these demos might also vary from section to section.  The specifications for the different sections are listed below:
+* [Section 6](demo-sec6.md)
 
 Select projects may be hosted in our project showcase. Here are selected projects from Fall 2022 [project showcase](https://neu-se.github.io/CS4530-Fall-2022/assignments/project-showcase).
 


### PR DESCRIPTION
Put specs for demos in my section as its own document, linked by a bullet point in project-grading.md . 

I think this is probably better than referring to Piazza.  What do you think?

FWIW, I created the link by saying `[Section 6](demo-sec6.md)` instead of the `({{site.baseurl}}{% link tutorials/week1-getting-started.md.blahblahblah %}) ` boilerplate, and it seems to work, at least in my local build.  I will check this again when the github deployment finishes.

  